### PR TITLE
Correct epoll preventing further read if buffer was too small

### DIFF
--- a/srcs/client/Client.cpp
+++ b/srcs/client/Client.cpp
@@ -62,6 +62,10 @@ int	Client::readHandler(void)
 	int read = recv(_socket, buffer, 4096, MSG_DONTWAIT);
 	if (read < 0)
 		throw std::runtime_error("[READ] : Error");
+	else if (read == 0)
+	{
+		return (-1);
+	}
 	_read += std::string(buffer);
 	if (_read.rfind("\r\n\r\n") != std::string::npos)
 	{


### PR DESCRIPTION
Remove EPOLLET to notify each time an fd is ready
Read_handler returns -1 if read was 0, to prevent infinite loop in epoll and removing client